### PR TITLE
CI: Changing Windows Shell to msys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,10 +22,14 @@ jobs:
   build-windows:
     name: Check on Windows
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
+    - uses: msys2/setup-msys2@v2
     - uses: actions/checkout@v3
-    - uses: ilammy/msvc-dev-cmd@v1
-    - uses: leafo/gh-actions-lua@v10
+    - name: Install Rust & Lua
+      run: pacman -S --noconfirm mingw-w64-x86_64-rust mingw-w64-x86_64-lua mingw-w64-x86_64-luajit mingw-w64-x86_64-pkg-config
     - name: Build
       run: cargo build --verbose
   build-macos:


### PR DESCRIPTION
All 3 Actions are working.

All i did was change windows shell to `msys2` and install **Rust** and **Lua** using pacman _(from arch btw)_.

It might not be the closest to an usual "Windows Default Shell scenario"  (like `cmd` or `PowerShell`) but it's an strategy used on [mlua's CI](https://github.com/mlua-rs/mlua/blob/83c075c72bd07747f0ad59a448ae8a4a58d9e402/.github/workflows/main.yml#L188C1-L208C1)