### PR TITLE
Add `delete` key support

### DIFF
--- a/src/command_bar.rs
+++ b/src/command_bar.rs
@@ -356,7 +356,6 @@ impl CommandBar {
                 }
 
                 if self.command_line_idx > 0 {
-                    self.update_command_list();
                     self.command_line_idx -= 1;
                     self.command_line = self
                         .command_line
@@ -370,6 +369,7 @@ impl CommandBar {
                             }
                         })
                         .collect();
+                    self.update_command_list();
                 }
 
                 if self.command_line.chars().count() > 0
@@ -381,11 +381,10 @@ impl CommandBar {
                 }
             }
             KeyCode::Delete => {
-                if self.command_line.chars().count() == 1 {
+                if self.command_line.chars().count() == 0 {
                     self.show_hint();
                 }
 
-                self.update_command_list();
                 self.command_line = self
                     .command_line
                     .chars()
@@ -398,6 +397,7 @@ impl CommandBar {
                         }
                     })
                     .collect();
+                self.update_command_list();
 
                 if self.command_line.chars().count() > 0
                     && self.command_line.chars().all(|x| x.is_whitespace())

--- a/src/command_bar.rs
+++ b/src/command_bar.rs
@@ -380,6 +380,33 @@ impl CommandBar {
                     self.show_hint();
                 }
             }
+            KeyCode::Delete => {
+                if self.command_line.chars().count() == 1 {
+                    self.show_hint();
+                }
+
+                self.update_command_list();
+                self.command_line = self
+                    .command_line
+                    .chars()
+                    .enumerate()
+                    .filter_map(|(i, c)| {
+                        if i != self.command_line_idx {
+                            Some(c)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                if self.command_line.chars().count() > 0
+                    && self.command_line.chars().all(|x| x.is_whitespace())
+                {
+                    self.command_line.clear();
+                    self.command_line_idx = 0;
+                    self.show_hint();
+                }
+            }
             KeyCode::Right => {
                 if self.command_line_idx == self.command_line.chars().count() {
                     return Ok(());


### PR DESCRIPTION
Adds `delete` key support on the command bar

Deletes the character on the right of the cursor when the `delete` key is pressed