### PR TITLE
Fix building as of rust version - nightly 1.80

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 #![deny(warnings)]
-#![feature(utf8_chunks)]
-#![feature(never_type)]
 
 extern crate core;
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -3,7 +3,6 @@ use crate::text::ViewData;
 use chrono::{DateTime, Local};
 use ratatui::style::Color;
 use std::borrow::Cow;
-use std::str::Utf8Chunks;
 
 pub enum UserTxData {
     Data {
@@ -64,7 +63,7 @@ impl SerialRxData {
     }
 
     fn from_utf8_print_invalid(v: &[u8]) -> Cow<'_, str> {
-        let mut iter = Utf8Chunks::new(v);
+        let mut iter = v.utf8_chunks();
 
         let chunk = if let Some(chunk) = iter.next() {
             let valid = chunk.valid();


### PR DESCRIPTION
After 1.79 on the nightly branch of rust the feature Utf8Chunks became stable, causing the following build error:

![image](https://github.com/matheuswhite/scope-rs/assets/92185892/f9d1f9b2-b10c-4696-86ec-926c5c0bd6ec)

This PR is meant to fix it. On the next rust update (currently 1.78) scope-rs will be back on the rust's stable branch!