### PR TITLE
Add `Home` & `End` Key support for the command bar

### DIFF
--- a/src/command_bar.rs
+++ b/src/command_bar.rs
@@ -466,6 +466,12 @@ impl CommandBar {
                 self.command_line_idx = self.command_line.chars().count();
                 self.update_command_list();
             }
+            KeyCode::End => {
+                self.command_line_idx = self.command_line.chars().count();
+            }
+            KeyCode::Home => {
+                self.command_line_idx = 0;
+            }
             KeyCode::Esc => {
                 let interface = self.interface.lock().await;
                 interface.exit().await;


### PR DESCRIPTION
- `Home` key to go to the beginning of the command bar input
- `End` key to go to the end of the command bar input

Closes #75 