### PR TITLE
Make "space" one of the valid characters in replace_hex_sequence function

### DIFF
--- a/src/inputs/inputs_task.rs
+++ b/src/inputs/inputs_task.rs
@@ -758,7 +758,7 @@ impl InputsTask {
     fn replace_hex_sequence(command_line: String) -> Vec<u8> {
         let mut output = vec![];
         let mut in_hex_seq = false;
-        let valid = "0123456789abcdefABCDEF,_-.";
+        let valid = "0123456789abcdefABCDEF,_-. ";
         let mut hex_shift = 0;
         let mut hex_val = None;
 


### PR DESCRIPTION
Make "space" one of the valid characters in replace_hex_sequence, 
so that hexadecimal message can have spaces and commas as separators as stated in README.